### PR TITLE
Added tests for next method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 npm-debug.log*
 node_modules/
 .idea/
+coverage/

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">=8.0.0"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -25,5 +25,8 @@
   "bugs": {
     "url": "https://github.com/fremail/ask-sdk-router/issues"
   },
-  "homepage": "https://github.com/fremail/ask-sdk-router#readme"
+  "homepage": "https://github.com/fremail/ask-sdk-router#readme",
+  "devDependencies": {
+    "jest": "^24.9.0"
+  }
 }

--- a/tests/next.test.js
+++ b/tests/next.test.js
@@ -1,0 +1,50 @@
+const Router = require('../index')
+
+describe('Router next', () => {
+    it('should return false when there is no handler', async () => {
+        const router = new Router({});
+
+        const result = await router.next({});
+
+        expect(result).toBe(false);
+    })
+
+    it('should call canHandle method when there is handler defined', async () => {
+        const Handler = {
+            canHandle: jest.fn()
+        };
+        const router = new Router({Handler});
+
+        await router.next({});
+
+        expect(Handler.canHandle).toBeCalled();
+    })
+
+    it('should call handle method when canHandle returns true', async () => {
+        const Handler = {
+            canHandle: () => true,
+            handle: jest.fn()
+        };
+
+        const router = new Router({Handler});
+
+        await router.next({});
+
+        expect(Handler.handle).toBeCalled();
+        expect(router.currentHandlerKey).toBe("Handler");
+    })
+
+    it('should not call handle method when canHandle returns false', async () => {
+        const Handler = {
+            canHandle: () => false,
+            handle: jest.fn()
+        };
+
+        const router = new Router({Handler});
+
+        await router.next({});
+
+        expect(Handler.handle).not.toBeCalled();
+        expect(router.currentHandlerKey).toBe("Handler");
+    })
+})


### PR DESCRIPTION
I've added some unit tests for `next` method. There is a new devDependency added - jest and ofc script for running tests. Also there is a new entry in gitignore - it contains directory created by `jest --coverage` tool.